### PR TITLE
Handle both log4j and log4net XML formats

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,6 @@ If the **timestamps are incorrect** (i.e. off by x hours): Remove existing confi
 
 * Add option to group by application (name only)
 * Export function
-* Test with log4j and log4net
 * Documentation for installation
 * Other data sources (database, file, etc.) via polling
 


### PR DESCRIPTION
They have a few subtle differences:
* timestamp is number of milliseconds (log4j) vs ISO 8601 (log4net)
* throwable (log4j) vs exception (log4net)
* log4jmachinename vs log4net:HostName